### PR TITLE
fix bug in next_between

### DIFF
--- a/lib/pwdhash/pwdhash.rb
+++ b/lib/pwdhash/pwdhash.rb
@@ -13,7 +13,7 @@ def rotate(array, amount)
 end
 
 def between(min, interval, offset)
-  (min.ord + offset.ord % interval).chr
+  (min.ord + offset.ord % interval)
 end
 
 def next_between(base, interval, extras)


### PR DESCRIPTION
Both next_between and between cast the value to char, this removes the call from between.
