### PR TITLE
Adding pwdhash2 with PBKDF2-SHA256 + salt + multiple iterations

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,7 @@ Generates PwdHash passwords from the command line.
 
 This is a simple Ruby command line tool to generate hashed passwords, using PwdHash's algorithm.
 
-PwdHash was written as a browser plugin, but sometimes we'd like to extend its use to desktop applications too. e.g. IM clients, Dropbox, etc. just to name a few.
+PwdHash was written as a browser plug-in, but sometimes we'd like to extend its use to desktop applications too. e.g. IM clients, Dropbox, etc. just to name a few.
 
 This tool is essentially a *straight* copy of [Chris Roos' implementation][chris-roos-impl], with a couple of command line interface improvements:
 
@@ -34,12 +34,35 @@ This tool is essentially a *straight* copy of [Chris Roos' implementation][chris
     > pwdhash example.com | clip # Or in Windows
     $ pwdhash example.com | putclip # Or in Cygwin
 
+## PwdHash2
+
+Some vulnerabilities of PwdHash have been exposed in [Cracking PwdHash: A Brute-force Attack on Client-side Password Hashing][cracking-pwdhash], along with a [proof-of-concept][pwdhash-poc] update to PwdHash. The updated algorithm (with PBKDF2-SHA256 + salt + multiple iterations) has been implemented as a Firefox Add-On at [GWuk/PwdHash2][gwuk-pwdhash2].
+
+The corresponding algorithm can be used with:
+
+    $ pwdhash2 URI [SALT] [ITERATIONS]
+
+    $ pwdhash2 example.com ReplaceThisSalt 50_000
+    Password for example.com (salt = 'ReplaceThisSalt', iterations = 50000):
+    IHC8WhmO40v
+
+*SALT* can be defined in `PWDHASH2_SALT` environment variable.
+
+*ITERATIONS* can be defined in `PWDHASH2_ITERATIONS` environment variable.
+
+    $ pwdhash2 example.com | xclip -selection c # Put generated password to X clipboard (paste with CTRL+V)
+
 ## Attribution
 
 The library part of this tool is a *straight* copy of [Chris Roos' implementation][chris-roos-impl]. The reason this git repository is set up is because: a) Chris Roos decided to put the code in an obscure corner in a pile of code which makes it hard for people to find and b) GitHub uses git :p
 
-The PwdHash plugin and the PwdHash algorithm is contributed by [Stanford PwdHash][stanford-pwdhash].
+The PwdHash plug-in and the PwdHash algorithm is contributed by [Stanford PwdHash][stanford-pwdhash].
+
+The PwdHash2 algorithm is contributed by [David Llewellyn-Jones and Graham Rymer][pwdhash-poc].
 
 [chris-roos-impl]: http://chrisroos.co.uk/blog/2007-04-11-getting-to-grips-with-pwdhash
 [stanford-pwdhash]: http://pwdhash.com
 [usenix-paper]: http://crypto.stanford.edu/PwdHash/pwdhash.pdf
+[cracking-pwdhash]: https://www.researchgate.net/publication/316267246_Cracking_PwdHash_A_Bruteforce_Attack_on_Client-side_Password_Hashing
+[pwdhash-poc]: https://github.com/llewelld/pwdhash-poc
+[gwuk-pwdhash2]: https://github.com/GWuk/PwdHash2/

--- a/README.markdown
+++ b/README.markdown
@@ -28,7 +28,8 @@ This tool is essentially a *straight* copy of [Chris Roos' implementation][chris
     Password for example.com:
     5NBoCKraALBs
 
-    $ pwdhash example.com | xclip # Put generated password to X clipboard
+    $ pwdhash example.com | xclip # Put generated password to X clipboard (paste with middle-click)
+    $ pwdhash example.com | xclip -selection c # Put generated password to X clipboard (paste with CTRL+V)
     $ pwdhash example.com | pbcopy # Or in OS X
     > pwdhash example.com | clip # Or in Windows
     $ pwdhash example.com | putclip # Or in Cygwin

--- a/README.markdown
+++ b/README.markdown
@@ -28,7 +28,7 @@ This tool is essentially a *straight* copy of [Chris Roos' implementation][chris
     Password for example.com:
     5NBoCKraALBs
 
-    $ pwdhash example.com | xcilp # Put generated password to X clipboard
+    $ pwdhash example.com | xclip # Put generated password to X clipboard
     $ pwdhash example.com | pbcopy # Or in OS X
     > pwdhash example.com | clip # Or in Windows
     $ pwdhash example.com | putclip # Or in Cygwin

--- a/bin/pwdhash
+++ b/bin/pwdhash
@@ -8,8 +8,6 @@ require 'pwdhash/pwdhash'
 require 'pwdhash/extract_domain'
 require 'pwdhash/version'
 
-require 'backports'
-
 def usage
     puts "pwdhash.rb #{PwdHash::VERSION} - Chris Yuen, Chris Roos (2012)"
     puts "Usage: pwdhash URI"

--- a/bin/pwdhash2
+++ b/bin/pwdhash2
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+
+require 'rubygems'
+require 'highline/import'
+require 'pathname'
+
+require 'pwdhash/pwdhash'
+require 'pwdhash/extract_domain'
+require 'pwdhash/version'
+
+require 'backports'
+
+def usage
+  puts "pwdhash.rb #{PwdHash::VERSION} - Chris Yuen, Chris Roos (2012)"
+  puts "Usage: pwdhash2 URI [SALT] [ITERATIONS]"
+  puts "Example: pwdhash2 https://mail.google.com"
+  puts "Example: pwdhash2 https://mail.google.com SomeSalt"
+  puts "Example: pwdhash2 https://mail.google.com SomeSalt 10_000"
+  puts
+  puts "SALT       can also be defined in PWDHASH2_SALT environment variable."
+  puts "ITERATIONS can also be defined in PWDHASH2_ITERATIONS environment variable."
+  exit
+end
+
+usage if ARGV.length == 0
+
+realm = extract_domain(ARGV[0])
+
+salt = ARGV[1] || ENV['PWDHASH2_SALT']
+iterations = (ARGV[2] || ENV['PWDHASH2_ITERATIONS'] || 50_000).to_i
+
+hl = HighLine.new($stdin, $stderr)
+password = hl.ask("Password for #{realm} (salt = '#{salt}', iterations = #{iterations}): ") {|q| q.echo = false}
+
+print get_hashed_password2(password, realm, salt, iterations)

--- a/bin/pwdhash2
+++ b/bin/pwdhash2
@@ -11,7 +11,7 @@ require 'pwdhash/version'
 require 'backports'
 
 def usage
-  puts "pwdhash.rb #{PwdHash::VERSION} - Chris Yuen, Chris Roos (2012)"
+  puts "pwdhash.rb #{PwdHash::VERSION} - Chris Yuen, Chris Roos (2012) Eric Duminil (2019)"
   puts "Usage: pwdhash2 URI [SALT] [ITERATIONS]"
   puts "Example: pwdhash2 https://mail.google.com"
   puts "Example: pwdhash2 https://mail.google.com SomeSalt"

--- a/bin/pwdhash2
+++ b/bin/pwdhash2
@@ -30,6 +30,7 @@ salt = ARGV[1] || ENV['PWDHASH2_SALT']
 iterations = (ARGV[2] || ENV['PWDHASH2_ITERATIONS'] || 50_000).to_i
 
 hl = HighLine.new($stdin, $stderr)
+hl.say("WARNING: Empty salt!") if salt.empty?
 password = hl.ask("Password for #{realm} (salt = '#{salt}', iterations = #{iterations}): ") {|q| q.echo = false}
 
 print get_hashed_password2(password, realm, salt, iterations)

--- a/lib/pwdhash/pwdhash.rb
+++ b/lib/pwdhash/pwdhash.rb
@@ -46,7 +46,6 @@ def apply_constraints(hash, size, nonalphanumeric)
   return result.join('')
 end
 
-require 'hmac-md5'
 require 'base64'
 require 'openssl'
 
@@ -66,7 +65,7 @@ module PwdHash
     end
   private
     def hash!
-      @hash = Base64.encode64(HMAC::MD5.digest(@password, @realm)).strip
+      @hash = Base64.encode64(OpenSSL::HMAC.digest("MD5", @password, @realm)).strip
     end
     def remove_base64_pad_character
       @hash.sub!(/=+$/, '')

--- a/lib/pwdhash/pwdhash.rb
+++ b/lib/pwdhash/pwdhash.rb
@@ -26,7 +26,7 @@ def contains(result, regex)
 end
 
 def apply_constraints(hash, size, nonalphanumeric)
-  startingSize = size - 4 # Leave room for some extra characters
+  startingSize = [size - 4, 0].max # Leave room for some extra characters
   result = hash[0, startingSize]
   extras = (hash[startingSize, hash.length] || "").split('')
   

--- a/lib/pwdhash/version.rb
+++ b/lib/pwdhash/version.rb
@@ -1,3 +1,3 @@
 module PwdHash
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end

--- a/lib/pwdhash/version.rb
+++ b/lib/pwdhash/version.rb
@@ -1,3 +1,3 @@
 module PwdHash
-  VERSION = "0.3.3"
+  VERSION = "0.3.4"
 end

--- a/pwdhash.gemspec
+++ b/pwdhash.gemspec
@@ -20,6 +20,4 @@ Gem::Specification.new do |gem|
   gem.version       = PwdHash::VERSION
 
   gem.add_dependency('highline', '~> 1.6', '>= 1.6.12')
-  gem.add_dependency('ruby-hmac', '~> 0.4', '>= 0.4.0')
-  gem.add_dependency('backports', '~> 3.6', '>= 3.6.4')
 end

--- a/pwdhash_test.rb
+++ b/pwdhash_test.rb
@@ -4,16 +4,30 @@ require 'minitest/pride'
 require 'minitest/autorun'
 
 require './lib/pwdhash/pwdhash'
+require './lib/pwdhash/extract_domain'
 
 class PwdHashTest < Minitest::Test
-  def test_passwords
+  def test_passwords_with_domains
     [
       ['v0F0B', 'foo', 'skype.com'],
       ['paZTVGZwtewiq1+uCk', 'a l0ng p4assw0rd', 'google.com'],
       ['nRDL7WNyFODhF29gAkNmpA', 'qwertyuiop0987654321', 'google.com'],
       ['edi6wHWRQVA1rK8o9zaluwAAAA', 'qwertyuiop0987654321bingo', 'google.com'],
+      ['8JyURsRs', 'foobar', 'thetimes.co.uk'],
     ].each do |expected, password, realm|
       assert_equal expected, get_hashed_password(password, realm)
+    end
+  end
+
+  def test_passwords_with_complete_urls
+    [
+      ['v0F0B', 'foo', 'https://www.whatever.skype.com'],
+      ['paZTVGZwtewiq1+uCk', 'a l0ng p4assw0rd', 'https://images.google.com'],
+      ['nRDL7WNyFODhF29gAkNmpA', 'qwertyuiop0987654321', 'http://google.com'],
+      ['edi6wHWRQVA1rK8o9zaluwAAAA', 'qwertyuiop0987654321bingo', 'https://news.google.com'],
+      ['8JyURsRs', 'foobar', 'https://www.thetimes.co.uk/'],
+    ].each do |expected, password, url|
+      assert_equal expected, get_hashed_password(password, extract_domain(url))
     end
   end
 end

--- a/pwdhash_test.rb
+++ b/pwdhash_test.rb
@@ -40,7 +40,14 @@ class PwdHash2Test < Minitest::Test
       ['r8oIM4CR', 'foobar', 1, 'ChangeMe', 'https://google.com'],
       ['3PvCifzNoYaTNBMcJzVvDfDBeVK', 'correcthorsebatterystaple', 50000, 'COVwVNWVhwCsd7vlQ2T5BuIJBccYCu1RzR8rQFVHYVkGVQkZXHLkglnttWFQJYIN', 'https://about.google/intl/en/?fg=1&utm_source=google-EN&utm_medium=referral&utm_campaign=hp-header'],
       ['APC8mNJI', 'foobar', 1000, 'ChangeMe', 'https://google.com'],
-      # Edge cases, for testing only! Please always define salt and password. Number of iterations shouldn't be too low.
+    ].each do |expected, password, iterations, salt, url|
+      assert_equal expected, get_hashed_password2(password, extract_domain(url), salt, iterations)
+    end
+  end
+
+  def test_edge_cases
+    # For testing only! Please always define salt and password. Number of iterations shouldn't be too low.
+    [
       ['WWNEC9x1', 'foobar', 1000, '', 'https://google.com'],
       ['EBr2', '', 1000, '', 'https://google.com'],
       ['w0WD', '', 1, '', 'https://google.com'],

--- a/pwdhash_test.rb
+++ b/pwdhash_test.rb
@@ -36,10 +36,12 @@ class PwdHash2Test < Minitest::Test
   def test_passwords_with_complete_urls
     # expected results calculated with https://gwuk.github.io/PwdHash2/pwdhash2/
     [
+      ['5YrAI', 'foo', 10000, 'SomeSalt', 'https://www.skype.com/en/'],
       ['r8oIM4CR', 'foobar', 1, 'ChangeMe', 'https://google.com'],
+      ['3PvCifzNoYaTNBMcJzVvDfDBeVK', 'correcthorsebatterystaple', 50000, 'COVwVNWVhwCsd7vlQ2T5BuIJBccYCu1RzR8rQFVHYVkGVQkZXHLkglnttWFQJYIN', 'https://about.google/intl/en/?fg=1&utm_source=google-EN&utm_medium=referral&utm_campaign=hp-header'],
       ['APC8mNJI', 'foobar', 1000, 'ChangeMe', 'https://google.com'],
     ].each do |expected, password, iterations, salt, url|
-      assert_equal expected, get_hashed_password2(password, iterations, salt, extract_domain(url))
+      assert_equal expected, get_hashed_password2(password, extract_domain(url), salt, iterations)
     end
   end
 end

--- a/pwdhash_test.rb
+++ b/pwdhash_test.rb
@@ -40,6 +40,12 @@ class PwdHash2Test < Minitest::Test
       ['r8oIM4CR', 'foobar', 1, 'ChangeMe', 'https://google.com'],
       ['3PvCifzNoYaTNBMcJzVvDfDBeVK', 'correcthorsebatterystaple', 50000, 'COVwVNWVhwCsd7vlQ2T5BuIJBccYCu1RzR8rQFVHYVkGVQkZXHLkglnttWFQJYIN', 'https://about.google/intl/en/?fg=1&utm_source=google-EN&utm_medium=referral&utm_campaign=hp-header'],
       ['APC8mNJI', 'foobar', 1000, 'ChangeMe', 'https://google.com'],
+      # Edge cases, for testing only! Please always define salt and password. Number of iterations shouldn't be too low.
+      ['WWNEC9x1', 'foobar', 1000, '', 'https://google.com'],
+      ['EBr2', '', 1000, '', 'https://google.com'],
+      ['w0WD', '', 1, '', 'https://google.com'],
+      ['w0WD', '', 0, '', 'https://google.com'],
+      ['w0WD', '', -1, '', 'https://google.com'],
     ].each do |expected, password, iterations, salt, url|
       assert_equal expected, get_hashed_password2(password, extract_domain(url), salt, iterations)
     end

--- a/pwdhash_test.rb
+++ b/pwdhash_test.rb
@@ -31,3 +31,15 @@ class PwdHashTest < Minitest::Test
     end
   end
 end
+
+class PwdHash2Test < Minitest::Test
+  def test_passwords_with_complete_urls
+    # expected results calculated with https://gwuk.github.io/PwdHash2/pwdhash2/
+    [
+      ['r8oIM4CR', 'foobar', 1, 'ChangeMe', 'https://google.com'],
+      ['APC8mNJI', 'foobar', 1000, 'ChangeMe', 'https://google.com'],
+    ].each do |expected, password, iterations, salt, url|
+      assert_equal expected, get_hashed_password2(password, iterations, salt, extract_domain(url))
+    end
+  end
+end

--- a/pwdhash_test.rb
+++ b/pwdhash_test.rb
@@ -45,8 +45,20 @@ class PwdHash2Test < Minitest::Test
     end
   end
 
+  def test_collisions_with_weak_passwords
+    # => Use a longer password!
+    [
+      ['foo', 1000, 'bar', 'https://manifolds.org', 'https://boxwoods.com'],
+      ['foo', 50_000, 'aYcErTYgi0AoB2tDbP80fwR5GAWwUvg8', 'http://dainty.co.uk', 'http://polemic.com'],
+      ['foobar', 100, 'salt', 'https://abounds.edu.au', 'https://coaxed.co.nz'],
+    ].each do |password, iterations, salt, url1, url2|
+      assert_equal get_hashed_password2(password, extract_domain(url1), salt, iterations),
+        get_hashed_password2(password, extract_domain(url2), salt, iterations)
+    end
+  end
+
   def test_edge_cases
-    # For testing only! Please always define salt and password. Number of iterations shouldn't be too low.
+    # For testing only! Please always define salt and password. Number of iterations shouldn't be too low and password should be long enough.
     [
       ['WWNEC9x1', 'foobar', 1000, '', 'https://google.com'],
       ['EBr2', '', 1000, '', 'https://google.com'],


### PR DESCRIPTION
Some vulnerabilities of PwdHash have been exposed in [Cracking PwdHash: A Brute-force Attack on Client-side Password Hashing][cracking-pwdhash], along with a [proof-of-concept][pwdhash-poc] update to PwdHash. The updated algorithm (with PBKDF2-SHA256 + salt + multiple iterations) has been implemented as a Firefox Add-On at [GWuk/PwdHash2][gwuk-pwdhash2].

The corresponding algorithm can be used with:

    $ pwdhash2 URI [SALT] [ITERATIONS]

    $ pwdhash2 example.com ReplaceThisSalt 50_000
    Password for example.com (salt = 'ReplaceThisSalt', iterations = 50000):
    IHC8WhmO40v

*SALT* can be defined in `PWDHASH2_SALT` environment variable.

*ITERATIONS* can be defined in `PWDHASH2_ITERATIONS` environment variable.

[cracking-pwdhash]: https://www.researchgate.net/publication/316267246_Cracking_PwdHash_A_Bruteforce_Attack_on_Client-side_Password_Hashing
[pwdhash-poc]: https://github.com/llewelld/pwdhash-poc
[gwuk-pwdhash2]: https://github.com/GWuk/PwdHash2/
